### PR TITLE
Fix afterAll ops and resource assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Test Suite
 
-[![version](https://img.shields.io/badge/release-0.9.1-success)](https://deno.land/x/test_suite@0.9.1)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.9.1/mod.ts)
+[![version](https://img.shields.io/badge/release-0.9.2-success)](https://deno.land/x/test_suite@0.9.2)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.9.2/mod.ts)
 [![CI](https://github.com/udibo/test_suite/workflows/CI/badge.svg)](https://github.com/udibo/test_suite/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/test_suite/branch/master/graph/badge.svg?token=EFKGY72AAV)](https://codecov.io/gh/udibo/test_suite)
 [![license](https://img.shields.io/github/license/udibo/test_suite)](https://github.com/udibo/test_suite/blob/master/LICENSE)
@@ -26,16 +26,16 @@ also be imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { TestSuite, test } from "https://deno.land/x/test_suite@0.9.1/mod.ts";
+import { TestSuite, test } from "https://deno.land/x/test_suite@0.9.2/mod.ts";
 // Import from GitHub
-import { TestSuite, test } "https://raw.githubusercontent.com/udibo/test_suite/0.9.1/mod.ts";
+import { TestSuite, test } "https://raw.githubusercontent.com/udibo/test_suite/0.9.2/mod.ts";
 ```
 
 ## Usage
 
 Below are some examples of how to use TestSuite and test in tests.
 
-See [deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.9.1/mod.ts)
+See [deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.9.2/mod.ts)
 for more information.
 
 ### TestSuite
@@ -56,13 +56,13 @@ except they are called before and after each individual test.
 The example test below can be found in the example directory.
 
 ```ts
-import { test, TestSuite } from "https://deno.land/x/test_suite@0.9.1/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.114.0/testing/asserts.ts";
+import { test, TestSuite } from "https://deno.land/x/test_suite@0.9.2/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.117.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.9.1/example/user.ts";
+} from "https://deno.land/x/test_suite@0.9.2/example/user.ts";
 
 interface UserSuiteContext {
   user: User;
@@ -139,13 +139,13 @@ import {
   beforeEach,
   describe,
   it,
-} from "https://deno.land/x/test_suite@0.9.1/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.114.0/testing/asserts.ts";
+} from "https://deno.land/x/test_suite@0.9.2/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.117.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.9.1/examples/user.ts";
+} from "https://deno.land/x/test_suite@0.9.2/examples/user.ts";
 
 describe("user describe", () => {
   let user: User;

--- a/test_suite.ts
+++ b/test_suite.ts
@@ -323,29 +323,29 @@ export class TestSuite<T> {
     this.hooks = {};
     TestSuite.setHooks(this, options);
     this.beforeAll = async () => {
+      if (this.suite) {
+        await this.suite.beforeAll();
+        this.context = { ...this.suite.context, ...this.context };
+      }
       if (this.sanitizeOps ?? true) {
         this.beforeAllMetrics = await getMetrics();
       }
       if (this.sanitizeResources ?? true) {
         this.beforeAllResources = Deno.resources();
       }
-      if (this.suite) {
-        await this.suite.beforeAll();
-        this.context = { ...this.suite.context, ...this.context };
-      }
       if (this.hooks.beforeAll) await this.hooks.beforeAll(this.context as T);
       this.started = true;
     };
     this.afterAll = async () => {
       if (this.hooks.afterAll) await this.hooks.afterAll(this.context as T);
-      if (this.suite && this.suite.last === this.last) {
-        await this.suite.afterAll();
-      }
       if (this.sanitizeOps ?? true) {
         await assertOps("suite", this.beforeAllMetrics!);
       }
       if (this.sanitizeResources ?? true) {
         assertResources("suite", this.beforeAllResources!);
+      }
+      if (this.suite && this.suite.last === this.last) {
+        await this.suite.afterAll();
       }
     };
     this.beforeEach = async (context: T) => {


### PR DESCRIPTION
The order of checks was incorrect. It was calling the afterAll for all functions before making the assertions. It should only call the afterAll for the current test before asserting ops or resources, then continue to the parent suites afterAll afterwards. This would cause failures if the test is last in its suite.

When saving the initial metrics and resources beforeAll tests, it was checking before calling beforeAll on all the parent tests. The initial metrics and resources for a test suite should be saved after all the parent test suites beforeAll calls finish.

This was calling tests to fail whenever a nested suite was first or last in the parent suite when the parent suite has a beforeAll or afterAll function that use ops or open resources.