### PR TITLE
Fix issues with beforeAll and afterAll hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Test Suite
 
-[![version](https://img.shields.io/badge/release-0.9.2-success)](https://deno.land/x/test_suite@0.9.2)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.9.2/mod.ts)
+[![version](https://img.shields.io/badge/release-0.9.3-success)](https://deno.land/x/test_suite@0.9.3)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.9.3/mod.ts)
 [![CI](https://github.com/udibo/test_suite/workflows/CI/badge.svg)](https://github.com/udibo/test_suite/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/test_suite/branch/master/graph/badge.svg?token=EFKGY72AAV)](https://codecov.io/gh/udibo/test_suite)
 [![license](https://img.shields.io/github/license/udibo/test_suite)](https://github.com/udibo/test_suite/blob/master/LICENSE)
@@ -26,16 +26,16 @@ also be imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { TestSuite, test } from "https://deno.land/x/test_suite@0.9.2/mod.ts";
+import { TestSuite, test } from "https://deno.land/x/test_suite@0.9.3/mod.ts";
 // Import from GitHub
-import { TestSuite, test } "https://raw.githubusercontent.com/udibo/test_suite/0.9.2/mod.ts";
+import { TestSuite, test } "https://raw.githubusercontent.com/udibo/test_suite/0.9.3/mod.ts";
 ```
 
 ## Usage
 
 Below are some examples of how to use TestSuite and test in tests.
 
-See [deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.9.2/mod.ts)
+See [deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.9.3/mod.ts)
 for more information.
 
 ### TestSuite
@@ -56,13 +56,13 @@ except they are called before and after each individual test.
 The example test below can be found in the example directory.
 
 ```ts
-import { test, TestSuite } from "https://deno.land/x/test_suite@0.9.2/mod.ts";
+import { test, TestSuite } from "https://deno.land/x/test_suite@0.9.3/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.117.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.9.2/example/user.ts";
+} from "https://deno.land/x/test_suite@0.9.3/example/user.ts";
 
 interface UserSuiteContext {
   user: User;
@@ -139,13 +139,13 @@ import {
   beforeEach,
   describe,
   it,
-} from "https://deno.land/x/test_suite@0.9.2/mod.ts";
+} from "https://deno.land/x/test_suite@0.9.3/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.117.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.9.2/examples/user.ts";
+} from "https://deno.land/x/test_suite@0.9.3/examples/user.ts";
 
 describe("user describe", () => {
   let user: User;

--- a/test_suite.ts
+++ b/test_suite.ts
@@ -324,7 +324,7 @@ export class TestSuite<T> {
     TestSuite.setHooks(this, options);
     this.beforeAll = async () => {
       try {
-        if (this.suite) {
+        if (this.suite && !this.suite.started) {
           await this.suite.beforeAll();
           this.context = { ...this.suite.context, ...this.context };
         }

--- a/test_suite.ts
+++ b/test_suite.ts
@@ -323,29 +323,35 @@ export class TestSuite<T> {
     this.hooks = {};
     TestSuite.setHooks(this, options);
     this.beforeAll = async () => {
-      if (this.suite) {
-        await this.suite.beforeAll();
-        this.context = { ...this.suite.context, ...this.context };
-      }
-      if (this.sanitizeOps ?? true) {
-        this.beforeAllMetrics = await getMetrics();
-      }
-      if (this.sanitizeResources ?? true) {
-        this.beforeAllResources = Deno.resources();
+      try {
+        if (this.suite) {
+          await this.suite.beforeAll();
+          this.context = { ...this.suite.context, ...this.context };
+        }
+      } finally {
+        this.started = true;
+        if (this.sanitizeOps ?? true) {
+          this.beforeAllMetrics = await getMetrics();
+        }
+        if (this.sanitizeResources ?? true) {
+          this.beforeAllResources = Deno.resources();
+        }
       }
       if (this.hooks.beforeAll) await this.hooks.beforeAll(this.context as T);
-      this.started = true;
     };
     this.afterAll = async () => {
-      if (this.hooks.afterAll) await this.hooks.afterAll(this.context as T);
-      if (this.sanitizeOps ?? true) {
-        await assertOps("suite", this.beforeAllMetrics!);
-      }
-      if (this.sanitizeResources ?? true) {
-        assertResources("suite", this.beforeAllResources!);
-      }
-      if (this.suite && this.suite.last === this.last) {
-        await this.suite.afterAll();
+      try {
+        if (this.hooks.afterAll) await this.hooks.afterAll(this.context as T);
+        if (this.sanitizeOps ?? true) {
+          await assertOps("suite", this.beforeAllMetrics!);
+        }
+        if (this.sanitizeResources ?? true) {
+          assertResources("suite", this.beforeAllResources!);
+        }
+      } finally {
+        if (this.suite && this.suite.last === this.last) {
+          await this.suite.afterAll();
+        }
       }
     };
     this.beforeEach = async (context: T) => {


### PR DESCRIPTION
If there was an error in the beforeAll for parent suites, the test would not get marked as started, resulting in beforeAll getting called for each test case until a test case passes.

When the parent suite had a beforeAll function, it would get called even if the suite had already started. This could cause failures if the beforeAll created async ops or opened resources.

I've manually tested this to verify it resolves the issues.