### PR TITLE
Fix hooks not being awaited

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Test Suite
 
-[![version](https://img.shields.io/badge/release-0.10.1-success)](https://deno.land/x/test_suite@0.10.1)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.10.1/mod.ts)
+[![version](https://img.shields.io/badge/release-0.10.2-success)](https://deno.land/x/test_suite@0.10.1)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.10.2/mod.ts)
 [![CI](https://github.com/udibo/test_suite/workflows/CI/badge.svg)](https://github.com/udibo/test_suite/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/test_suite/branch/main/graph/badge.svg?token=EFKGY72AAV)](https://codecov.io/gh/udibo/test_suite)
 [![license](https://img.shields.io/github/license/udibo/test_suite)](https://github.com/udibo/test_suite/blob/master/LICENSE)
@@ -26,9 +26,9 @@ also be imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { describe, it } from "https://deno.land/x/test_suite@0.10.1/mod.ts";
+import { describe, it } from "https://deno.land/x/test_suite@0.10.2/mod.ts";
 // Import from GitHub
-import { describe, it } "https://raw.githubusercontent.com/udibo/test_suite/0.10.1/mod.ts";
+import { describe, it } "https://raw.githubusercontent.com/udibo/test_suite/0.10.2/mod.ts";
 ```
 
 ## Usage
@@ -49,7 +49,7 @@ except they are called before and after each individual test.
 Below are some examples of how to use `describe` and `it` in tests.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.10.1/mod.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.10.2/mod.ts)
 for more information.
 
 ### Nested test grouping
@@ -62,13 +62,13 @@ import {
   beforeEach,
   describe,
   it,
-} from "https://deno.land/x/test_suite@0.10.1/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.126.0/testing/asserts.ts";
+} from "https://deno.land/x/test_suite@0.10.2/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.127.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.10.1/examples/user.ts";
+} from "https://deno.land/x/test_suite@0.10.2/examples/user.ts";
 
 describe("user describe", () => {
   let user: User;
@@ -126,13 +126,13 @@ test result: ok. 1 passed (5 steps); 0 failed; 0 ignored; 0 measured; 0 filtered
 The example below can be found [here](examples/user_flat_test.ts).
 
 ```ts
-import { describe, it } from "https://deno.land/x/test_suite@0.10.1/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.126.0/testing/asserts.ts";
+import { describe, it } from "https://deno.land/x/test_suite@0.10.2/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.127.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.10.1/example/user.ts";
+} from "https://deno.land/x/test_suite@0.10.2/examples/user.ts";
 
 interface UserContext {
   user: User;

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { delay } from "https://deno.land/std@0.126.0/async/delay.ts";
+export { delay } from "https://deno.land/std@0.127.0/async/delay.ts";
 export {
   assert,
   assertEquals,
@@ -7,6 +7,6 @@ export {
   assertRejects,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.126.0/testing/asserts.ts";
+} from "https://deno.land/std@0.127.0/testing/asserts.ts";
 
 export { Vector } from "https://deno.land/x/collections@0.11.2/vector.ts";

--- a/describe_test.ts
+++ b/describe_test.ts
@@ -78,22 +78,32 @@ Deno.test("global", async (t) => {
     eachTimer: number;
   }
 
+  function beforeAllFns() {
+    return {
+      beforeAllFn: spy(async (context: GlobalContext) => {
+        await Promise.resolve();
+        context.allTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
+      }),
+      afterAllFn: spy(async ({ allTimer }: GlobalContext) => {
+        await Promise.resolve();
+        clearTimeout(allTimer);
+      }),
+      beforeEachFn: spy(async (context: GlobalContext) => {
+        await Promise.resolve();
+        context.eachTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
+      }),
+      afterEachFn: spy(async ({ eachTimer }: GlobalContext) => {
+        await Promise.resolve();
+        clearTimeout(eachTimer);
+      }),
+    };
+  }
+
   await t.step("global hooks", async () => {
     const test = stub(Deno, "test"),
       time = new FakeTime(),
       fns = [spy(), spy()],
-      beforeAllFn = spy((context: GlobalContext) => {
-        context.allTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
-      }),
-      afterAllFn = spy(({ allTimer }: GlobalContext) => {
-        clearTimeout(allTimer);
-      }),
-      beforeEachFn = spy((context: GlobalContext) => {
-        context.eachTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
-      }),
-      afterEachFn = spy(({ eachTimer }: GlobalContext) => {
-        clearTimeout(eachTimer);
-      });
+      { beforeAllFn, afterAllFn, beforeEachFn, afterEachFn } = beforeAllFns();
 
     try {
       beforeAll(beforeAllFn);
@@ -1326,21 +1336,11 @@ Deno.test("global", async (t) => {
         ) => void,
       ) {
         const test = stub(Deno, "test"),
+          time = new FakeTime(),
           fns = [spy(), spy()],
-          beforeAllFn = spy((context: GlobalContext) => {
-            context.allTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
-          }),
-          afterAllFn = spy(({ allTimer }: GlobalContext) => {
-            clearTimeout(allTimer);
-          }),
-          beforeEachFn = spy((context: GlobalContext) => {
-            context.eachTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
-          }),
-          afterEachFn = spy(({ eachTimer }: GlobalContext) => {
-            clearTimeout(eachTimer);
-          });
+          { beforeAllFn, afterAllFn, beforeEachFn, afterEachFn } =
+            beforeAllFns();
 
-        const time = new FakeTime();
         try {
           cb({ beforeAllFn, afterAllFn, beforeEachFn, afterEachFn, fns });
 
@@ -1436,18 +1436,8 @@ Deno.test("global", async (t) => {
           const test = stub(Deno, "test"),
             time = new FakeTime(),
             fns = [spy(), spy()],
-            beforeAllFn = spy((context: GlobalContext) => {
-              context.allTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
-            }),
-            afterAllFn = spy(({ allTimer }: GlobalContext) => {
-              clearTimeout(allTimer);
-            }),
-            beforeEachFn = spy((context: GlobalContext) => {
-              context.eachTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
-            }),
-            afterEachFn = spy(({ eachTimer }: GlobalContext) => {
-              clearTimeout(eachTimer);
-            });
+            { beforeAllFn, afterAllFn, beforeEachFn, afterEachFn } =
+              beforeAllFns();
 
           try {
             describe("example", () => {
@@ -1521,36 +1511,34 @@ Deno.test("global", async (t) => {
           const test = stub(Deno, "test"),
             time = new FakeTime(),
             fns = [spy(), spy()],
-            beforeAllFn = spy((context: GlobalContext) => {
-              context.allTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
-            }),
-            afterAllFn = spy(({ allTimer }: GlobalContext) => {
-              clearTimeout(allTimer);
-            }),
-            beforeEachFn = spy((context: GlobalContext) => {
-              context.eachTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
-            }),
-            afterEachFn = spy(({ eachTimer }: GlobalContext) => {
-              clearTimeout(eachTimer);
-            }),
-            beforeAllFnNested = spy((context: NestedContext) => {
+            { beforeAllFn, afterAllFn, beforeEachFn, afterEachFn } =
+              beforeAllFns(),
+            beforeAllFnNested = spy(async (context: NestedContext) => {
+              await Promise.resolve();
               context.allTimerNested = setTimeout(
                 () => {},
                 Number.MAX_SAFE_INTEGER,
               );
             }),
-            afterAllFnNested = spy(({ allTimerNested }: NestedContext) => {
-              clearTimeout(allTimerNested);
-            }),
-            beforeEachFnNested = spy((context: NestedContext) => {
+            afterAllFnNested = spy(
+              async ({ allTimerNested }: NestedContext) => {
+                await Promise.resolve();
+                clearTimeout(allTimerNested);
+              },
+            ),
+            beforeEachFnNested = spy(async (context: NestedContext) => {
+              await Promise.resolve();
               context.eachTimerNested = setTimeout(
                 () => {},
                 Number.MAX_SAFE_INTEGER,
               );
             }),
-            afterEachFnNested = spy(({ eachTimerNested }: NestedContext) => {
-              clearTimeout(eachTimerNested);
-            });
+            afterEachFnNested = spy(
+              async ({ eachTimerNested }: NestedContext) => {
+                await Promise.resolve();
+                clearTimeout(eachTimerNested);
+              },
+            );
 
           try {
             describe("example", () => {

--- a/test_suite.ts
+++ b/test_suite.ts
@@ -102,7 +102,7 @@ export class TestSuite<T> {
           if (!TestSuite.running) TestSuite.running = true;
           const context = {} as T;
           if (this.describe.beforeAll) {
-            this.describe.beforeAll(context);
+            await this.describe.beforeAll(context);
           }
           try {
             TestSuite.active.push(this);
@@ -110,7 +110,7 @@ export class TestSuite<T> {
           } finally {
             TestSuite.active.pop();
             if (this.describe.afterAll) {
-              this.describe.afterAll(context);
+              await this.describe.afterAll(context);
             }
           }
         },
@@ -239,7 +239,7 @@ export class TestSuite<T> {
           context = { ...context };
           if (step instanceof TestSuite) {
             if (step.describe.beforeAll) {
-              step.describe.beforeAll(context);
+              await step.describe.beforeAll(context);
             }
             try {
               TestSuite.active.push(step);
@@ -247,7 +247,7 @@ export class TestSuite<T> {
             } finally {
               TestSuite.active.pop();
               if (step.describe.afterAll) {
-                step.describe.afterAll(context);
+                await step.describe.afterAll(context);
               }
             }
           } else {
@@ -271,13 +271,13 @@ export class TestSuite<T> {
     if (suite) {
       context = { ...context };
       if (suite.describe.beforeEach) {
-        suite.describe.beforeEach(context);
+        await suite.describe.beforeEach(context);
       }
       try {
         await TestSuite.runTest(fn, context, activeIndex + 1);
       } finally {
         if (suite.describe.afterEach) {
-          suite.describe.afterEach(context);
+          await suite.describe.afterEach(context);
         }
       }
     } else {


### PR DESCRIPTION
I found this issue when updating a private module of mine to using the latest version. The tests began leaking async ops because my hooks were creating database connections. There is also an issue in Deno 1.19 that made it less obvious because I was getting undefined is not iterable errors. After downgrading to Deno 1.18, the test failures showed me what async ops were leaking and I found the cause was lack of awaits.

I've updated the tests so that they will verify the hooks are awaited by making them all async.

Also closes https://github.com/udibo/test_suite/issues/17