### PR TITLE
Replace context arg with this

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Test Suite
 
-[![version](https://img.shields.io/badge/release-0.12.0-success)](https://deno.land/x/test_suite@0.12.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.12.0/mod.ts)
+[![version](https://img.shields.io/badge/release-0.13.0-success)](https://deno.land/x/test_suite@0.13.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.13.0/mod.ts)
 [![CI](https://github.com/udibo/test_suite/workflows/CI/badge.svg)](https://github.com/udibo/test_suite/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/test_suite/branch/main/graph/badge.svg?token=EFKGY72AAV)](https://codecov.io/gh/udibo/test_suite)
 [![license](https://img.shields.io/github/license/udibo/test_suite)](https://github.com/udibo/test_suite/blob/master/LICENSE)
@@ -26,12 +26,12 @@ also be imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { describe, it } from "https://deno.land/x/test_suite@0.12.0/mod.ts";
+import { describe, it } from "https://deno.land/x/test_suite@0.13.0/mod.ts";
 // Import from GitHub
 import {
   describe,
   it,
-} from "https://raw.githubusercontent.com/udibo/test_suite/0.12.0/mod.ts";
+} from "https://raw.githubusercontent.com/udibo/test_suite/0.13.0/mod.ts";
 ```
 
 ## Usage
@@ -44,7 +44,9 @@ specifically set them.
 The beforeAll and afterAll hook options can be used to do something before and
 after all the tests in the suite run. If you would like to set values for all
 tests within the suite, you can create a context interface that defines all the
-values available to the tests that are defined in the beforeAll function.
+values available to the tests that are defined in the beforeAll function using
+the this argument. An example of this can be found in the section for
+[flat test grouping](#flat-test-grouping).
 
 The beforeEach and afterEach hook options are similar to beforeAll and afterAll
 except they are called before and after each individual test.
@@ -52,7 +54,7 @@ except they are called before and after each individual test.
 Below are some examples of how to use `describe` and `it` in tests.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.12.0/mod.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.13.0/mod.ts)
 for more information.
 
 ### Nested test grouping
@@ -65,13 +67,13 @@ import {
   beforeEach,
   describe,
   it,
-} from "https://deno.land/x/test_suite@0.12.0/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.128.0/testing/asserts.ts";
+} from "https://deno.land/x/test_suite@0.13.0/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.129.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.12.0/examples/user.ts";
+} from "https://deno.land/x/test_suite@0.13.0/examples/user.ts";
 
 describe("user describe", () => {
   let user: User;
@@ -129,13 +131,13 @@ test result: ok. 1 passed (5 steps); 0 failed; 0 ignored; 0 measured; 0 filtered
 The example below can be found [here](examples/user_flat_test.ts).
 
 ```ts
-import { describe, it } from "https://deno.land/x/test_suite@0.12.0/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.128.0/testing/asserts.ts";
+import { describe, it } from "https://deno.land/x/test_suite@0.13.0/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.129.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.12.0/examples/user.ts";
+} from "https://deno.land/x/test_suite@0.13.0/examples/user.ts";
 
 interface UserContext {
   user: User;
@@ -143,8 +145,8 @@ interface UserContext {
 
 const userSuite = describe({
   name: "user",
-  beforeEach(context: UserContext) {
-    context.user = new User("Kyle June");
+  beforeEach(this: UserContext) {
+    this.user = new User("Kyle June");
   },
   afterEach() {
     resetUsers();
@@ -165,12 +167,12 @@ it(getUserSuite, "user does not exist", () => {
   assertEquals(getUser("John Doe"), undefined);
 });
 
-it(getUserSuite, "user exists", (context: UserContext) => {
-  assertEquals(getUser("Kyle June"), context.user);
+it(getUserSuite, "user exists", function (this: UserContext) {
+  assertEquals(getUser("Kyle June"), this.user);
 });
 
-it(userSuite, "resetUsers", (context: UserContext) => {
-  assertEquals(getUser("Kyle June"), context.user);
+it(userSuite, "resetUsers", function (this: UserContext) {
+  assertEquals(getUser("Kyle June"), this.user);
   resetUsers();
   assertEquals(getUser("Kyle June"), undefined);
 });

--- a/describe.ts
+++ b/describe.ts
@@ -16,21 +16,21 @@ type ItArgs<T> =
   ]
   | [
     name: string,
-    fn: (context: T) => void | Promise<void>,
+    fn: (this: T) => void | Promise<void>,
   ]
-  | [fn: (context: T) => void | Promise<void>]
+  | [fn: (this: T) => void | Promise<void>]
   | [
     name: string,
     options: Omit<ItDefinition<T>, "fn" | "name">,
-    fn: (context: T) => void | Promise<void>,
+    fn: (this: T) => void | Promise<void>,
   ]
   | [
     options: Omit<ItDefinition<T>, "fn">,
-    fn: (context: T) => void | Promise<void>,
+    fn: (this: T) => void | Promise<void>,
   ]
   | [
     options: Omit<ItDefinition<T>, "fn" | "name">,
-    fn: (context: T) => void | Promise<void>,
+    fn: (this: T) => void | Promise<void>,
   ]
   | [
     suite: TestSuite<T>,
@@ -40,27 +40,27 @@ type ItArgs<T> =
   | [
     suite: TestSuite<T>,
     name: string,
-    fn: (context: T) => void | Promise<void>,
+    fn: (this: T) => void | Promise<void>,
   ]
   | [
     suite: TestSuite<T>,
-    fn: (context: T) => void | Promise<void>,
+    fn: (this: T) => void | Promise<void>,
   ]
   | [
     suite: TestSuite<T>,
     name: string,
     options: Omit<ItDefinition<T>, "fn" | "name" | "suite">,
-    fn: (context: T) => void | Promise<void>,
+    fn: (this: T) => void | Promise<void>,
   ]
   | [
     suite: TestSuite<T>,
     options: Omit<ItDefinition<T>, "fn" | "suite">,
-    fn: (context: T) => void | Promise<void>,
+    fn: (this: T) => void | Promise<void>,
   ]
   | [
     suite: TestSuite<T>,
     options: Omit<ItDefinition<T>, "fn" | "name" | "suite">,
-    fn: (context: T) => void | Promise<void>,
+    fn: (this: T) => void | Promise<void>,
   ];
 
 /** Generates an ItDefinition from ItArgs. */
@@ -165,9 +165,9 @@ export function it<T>(...args: ItArgs<T>): void {
       sanitizeExit,
       sanitizeOps,
       sanitizeResources,
-      fn: async () => {
+      async fn() {
         if (!TestSuiteInternal.running) TestSuiteInternal.running = true;
-        await fn!({} as T);
+        await fn.call({} as T);
       },
     });
   }
@@ -191,7 +191,7 @@ it.ignore = function itIgnore<T>(...args: ItArgs<T>): void {
 
 function addHook<T>(
   name: HookNames,
-  fn: (context: T) => void | Promise<void>,
+  fn: (this: T) => void | Promise<void>,
 ): void {
   if (!TestSuiteInternal.current) {
     if (TestSuiteInternal.started) {
@@ -210,28 +210,28 @@ function addHook<T>(
 
 /** Run some shared setup before all of the tests in the suite. */
 export function beforeAll<T>(
-  fn: (context: T) => void | Promise<void>,
+  fn: (this: T) => void | Promise<void>,
 ): void {
   addHook("beforeAll", fn);
 }
 
 /** Run some shared teardown after all of the tests in the suite. */
 export function afterAll<T>(
-  fn: (context: T) => void | Promise<void>,
+  fn: (this: T) => void | Promise<void>,
 ): void {
   addHook("afterAll", fn);
 }
 
 /** Run some shared setup before each test in the suite. */
 export function beforeEach<T>(
-  fn: (context: T) => void | Promise<void>,
+  fn: (this: T) => void | Promise<void>,
 ): void {
   addHook("beforeEach", fn);
 }
 
 /** Run some shared teardown after each test in the suite. */
 export function afterEach<T>(
-  fn: (context: T) => void | Promise<void>,
+  fn: (this: T) => void | Promise<void>,
 ): void {
   addHook("afterEach", fn);
 }

--- a/describe_test.ts
+++ b/describe_test.ts
@@ -80,21 +80,21 @@ Deno.test("global", async (t) => {
 
   function beforeAllFns() {
     return {
-      beforeAllFn: spy(async (context: GlobalContext) => {
+      beforeAllFn: spy(async function (this: GlobalContext) {
         await Promise.resolve();
-        context.allTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
+        this.allTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
       }),
-      afterAllFn: spy(async ({ allTimer }: GlobalContext) => {
+      afterAllFn: spy(async function (this: GlobalContext) {
         await Promise.resolve();
-        clearTimeout(allTimer);
+        clearTimeout(this.allTimer);
       }),
-      beforeEachFn: spy(async (context: GlobalContext) => {
+      beforeEachFn: spy(async function (this: GlobalContext) {
         await Promise.resolve();
-        context.eachTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
+        this.eachTimer = setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
       }),
-      afterEachFn: spy(async ({ eachTimer }: GlobalContext) => {
+      afterEachFn: spy(async function (this: GlobalContext) {
         await Promise.resolve();
-        clearTimeout(eachTimer);
+        clearTimeout(this.eachTimer);
       }),
     };
   }
@@ -136,16 +136,16 @@ Deno.test("global", async (t) => {
 
     let fn = fns[0];
     assertSpyCall(fn, 0, {
-      self: undefined,
-      args: [{ allTimer: 1, eachTimer: 2 }],
+      self: { allTimer: 1, eachTimer: 2 },
+      args: [],
       returned: undefined,
     });
     assertSpyCalls(fn, 1);
 
     fn = fns[1];
     assertSpyCall(fn, 0, {
-      self: undefined,
-      args: [{ allTimer: 1, eachTimer: 3 }],
+      self: { allTimer: 1, eachTimer: 3 },
+      args: [],
       returned: undefined,
     });
     assertSpyCalls(fn, 1);
@@ -184,8 +184,8 @@ Deno.test("global", async (t) => {
         assertEquals(await result, undefined);
         assertSpyCalls(context.spies.step, 0);
         assertSpyCall(fn, 0, {
-          self: undefined,
-          args: [{}],
+          self: {},
+          args: [],
           returned: undefined,
         });
       } finally {
@@ -257,8 +257,8 @@ Deno.test("global", async (t) => {
     await t.step("signature 4", async () =>
       await assertMinimumOptions((fn) => {
         assertEquals(
-          it(function example() {
-            fn.apply(undefined, Array.from(arguments));
+          it(function example(this: void, ...args) {
+            fn.apply(this, args);
           }),
           undefined,
         );
@@ -311,8 +311,8 @@ Deno.test("global", async (t) => {
         async () =>
           await assertMinimumOptions((fn) => {
             assertEquals(
-              it({}, function example() {
-                fn.apply(undefined, Array.from(arguments));
+              it({}, function example(this: void, ...args) {
+                fn.apply(this, args);
               }),
               undefined,
             );
@@ -324,8 +324,8 @@ Deno.test("global", async (t) => {
           assertEquals(
             it({
               ...baseOptions,
-            }, function example() {
-              fn.apply(undefined, Array.from(arguments));
+            }, function example(this: void, ...args) {
+              fn.apply(this, args);
             }),
             undefined,
           );
@@ -401,8 +401,8 @@ Deno.test("global", async (t) => {
         async () =>
           await assertMinimumOptions((fn) => {
             assertEquals(
-              it.only(function example() {
-                fn.apply(undefined, Array.from(arguments));
+              it.only(function example(this: void, ...args) {
+                fn.apply(this, args);
               }),
               undefined,
             );
@@ -456,8 +456,8 @@ Deno.test("global", async (t) => {
           async () =>
             await assertMinimumOptions((fn) => {
               assertEquals(
-                it.only({}, function example() {
-                  fn.apply(undefined, Array.from(arguments));
+                it.only({}, function example(this: void, ...args) {
+                  fn.apply(this, args);
                 }),
                 undefined,
               );
@@ -469,8 +469,8 @@ Deno.test("global", async (t) => {
             assertEquals(
               it.only({
                 ...baseOptions,
-              }, function example() {
-                fn.apply(undefined, Array.from(arguments));
+              }, function example(this: void, ...args) {
+                fn.apply(this, args);
               }),
               undefined,
             );
@@ -547,8 +547,8 @@ Deno.test("global", async (t) => {
         async () =>
           await assertMinimumOptions((fn) => {
             assertEquals(
-              it.ignore(function example() {
-                fn.apply(undefined, Array.from(arguments));
+              it.ignore(function example(this: void, ...args) {
+                fn.apply(this, args);
               }),
               undefined,
             );
@@ -602,8 +602,8 @@ Deno.test("global", async (t) => {
           async () =>
             await assertMinimumOptions((fn) => {
               assertEquals(
-                it.ignore({}, function example() {
-                  fn.apply(undefined, Array.from(arguments));
+                it.ignore({}, function example(this: void, ...args) {
+                  fn.apply(this, args);
                 }),
                 undefined,
               );
@@ -615,8 +615,8 @@ Deno.test("global", async (t) => {
             assertEquals(
               it.ignore({
                 ...baseOptions,
-              }, function example() {
-                fn.apply(undefined, Array.from(arguments));
+              }, function example(this: void, ...args) {
+                fn.apply(this, args);
               }),
               undefined,
             );
@@ -657,15 +657,15 @@ Deno.test("global", async (t) => {
 
         let fn = fns[0];
         assertSpyCall(fn, 0, {
-          self: undefined,
-          args: [{}],
+          self: {},
+          args: [],
           returned: undefined,
         });
 
         fn = fns[1];
         assertSpyCall(fn, 0, {
-          self: undefined,
-          args: [{}],
+          self: {},
+          args: [],
           returned: undefined,
         });
         assertSpyCalls(fn, 1);
@@ -1264,8 +1264,8 @@ Deno.test("global", async (t) => {
 
           fn = fns[1];
           assertSpyCall(fn, 0, {
-            self: undefined,
-            args: [{}],
+            self: {},
+            args: [],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);
@@ -1365,16 +1365,16 @@ Deno.test("global", async (t) => {
 
         let fn = fns[0];
         assertSpyCall(fn, 0, {
-          self: undefined,
-          args: [{ allTimer: 1, eachTimer: 2 }],
+          self: { allTimer: 1, eachTimer: 2 },
+          args: [],
           returned: undefined,
         });
         assertSpyCalls(fn, 1);
 
         fn = fns[1];
         assertSpyCall(fn, 0, {
-          self: undefined,
-          args: [{ allTimer: 1, eachTimer: 3 }],
+          self: { allTimer: 1, eachTimer: 3 },
+          args: [],
           returned: undefined,
         });
         assertSpyCalls(fn, 1);
@@ -1479,16 +1479,16 @@ Deno.test("global", async (t) => {
 
           let fn = fns[0];
           assertSpyCall(fn, 0, {
-            self: undefined,
-            args: [{ allTimer: 1, eachTimer: 2 }],
+            self: { allTimer: 1, eachTimer: 2 },
+            args: [],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);
 
           fn = fns[1];
           assertSpyCall(fn, 0, {
-            self: undefined,
-            args: [{ allTimer: 1, eachTimer: 3 }],
+            self: { allTimer: 1, eachTimer: 3 },
+            args: [],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);
@@ -1513,30 +1513,30 @@ Deno.test("global", async (t) => {
             fns = [spy(), spy()],
             { beforeAllFn, afterAllFn, beforeEachFn, afterEachFn } =
               beforeAllFns(),
-            beforeAllFnNested = spy(async (context: NestedContext) => {
+            beforeAllFnNested = spy(async function (this: NestedContext) {
               await Promise.resolve();
-              context.allTimerNested = setTimeout(
+              this.allTimerNested = setTimeout(
                 () => {},
                 Number.MAX_SAFE_INTEGER,
               );
             }),
             afterAllFnNested = spy(
-              async ({ allTimerNested }: NestedContext) => {
+              async function (this: NestedContext) {
                 await Promise.resolve();
-                clearTimeout(allTimerNested);
+                clearTimeout(this.allTimerNested);
               },
             ),
-            beforeEachFnNested = spy(async (context: NestedContext) => {
+            beforeEachFnNested = spy(async function (this: NestedContext) {
               await Promise.resolve();
-              context.eachTimerNested = setTimeout(
+              this.eachTimerNested = setTimeout(
                 () => {},
                 Number.MAX_SAFE_INTEGER,
               );
             }),
             afterEachFnNested = spy(
-              async ({ eachTimerNested }: NestedContext) => {
+              async function (this: NestedContext) {
                 await Promise.resolve();
-                clearTimeout(eachTimerNested);
+                clearTimeout(this.eachTimerNested);
               },
             );
 
@@ -1586,26 +1586,26 @@ Deno.test("global", async (t) => {
 
           let fn = fns[0];
           assertSpyCall(fn, 0, {
-            self: undefined,
-            args: [{
+            self: {
               allTimer: 1,
               allTimerNested: 2,
               eachTimer: 3,
               eachTimerNested: 4,
-            }],
+            },
+            args: [],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);
 
           fn = fns[1];
           assertSpyCall(fn, 0, {
-            self: undefined,
-            args: [{
+            self: {
               allTimer: 1,
               allTimerNested: 2,
               eachTimer: 5,
               eachTimerNested: 6,
-            }],
+            },
+            args: [],
             returned: undefined,
           });
           assertSpyCalls(fn, 1);

--- a/examples/user_flat_test.ts
+++ b/examples/user_flat_test.ts
@@ -8,8 +8,8 @@ interface UserContext {
 
 const userSuite = describe({
   name: "user",
-  beforeEach(context: UserContext) {
-    context.user = new User("Kyle June");
+  beforeEach(this: UserContext) {
+    this.user = new User("Kyle June");
   },
   afterEach() {
     resetUsers();
@@ -30,12 +30,12 @@ it(getUserSuite, "user does not exist", () => {
   assertEquals(getUser("John Doe"), undefined);
 });
 
-it(getUserSuite, "user exists", (context: UserContext) => {
-  assertEquals(getUser("Kyle June"), context.user);
+it(getUserSuite, "user exists", function (this: UserContext) {
+  assertEquals(getUser("Kyle June"), this.user);
 });
 
-it(userSuite, "resetUsers", (context: UserContext) => {
-  assertEquals(getUser("Kyle June"), context.user);
+it(userSuite, "resetUsers", function (this: UserContext) {
+  assertEquals(getUser("Kyle June"), this.user);
   resetUsers();
   assertEquals(getUser("Kyle June"), undefined);
 });

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,4 +1,3 @@
-export { delay } from "https://deno.land/std@0.128.0/async/delay.ts";
 export {
   assert,
   assertEquals,
@@ -7,7 +6,7 @@ export {
   assertRejects,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.128.0/testing/asserts.ts";
+} from "https://deno.land/std@0.129.0/testing/asserts.ts";
 
 export {
   assertSpyCall,


### PR DESCRIPTION
If you are only using the nested test grouping syntax, this change should have no impact on you.

See diff for `examples/user_flat_test.ts` for an example of how to adapt existing flat test grouping code to the new call signature. I decided on making this change to make it easier to add arguments when later implementing the each function from [this issue](https://github.com/udibo/test_suite/issues/7). With context being the first argument, you would have to set a first argument that goes unused even if you are writing a test case that doesn't use context.