### PR TITLE
Fix nested only option only applying to current suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Test Suite
 
-[![version](https://img.shields.io/badge/release-0.14.0-success)](https://deno.land/x/test_suite@0.14.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.14.0/mod.ts)
+[![version](https://img.shields.io/badge/release-0.15.0-success)](https://deno.land/x/test_suite@0.15.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.15.0/mod.ts)
 [![CI](https://github.com/udibo/test_suite/workflows/CI/badge.svg)](https://github.com/udibo/test_suite/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/test_suite/branch/main/graph/badge.svg?token=EFKGY72AAV)](https://codecov.io/gh/udibo/test_suite)
 [![license](https://img.shields.io/github/license/udibo/test_suite)](https://github.com/udibo/test_suite/blob/master/LICENSE)
@@ -26,12 +26,12 @@ also be imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { describe, it } from "https://deno.land/x/test_suite@0.14.0/mod.ts";
+import { describe, it } from "https://deno.land/x/test_suite@0.15.0/mod.ts";
 // Import from GitHub
 import {
   describe,
   it,
-} from "https://raw.githubusercontent.com/udibo/test_suite/0.14.0/mod.ts";
+} from "https://raw.githubusercontent.com/udibo/test_suite/0.15.0/mod.ts";
 ```
 
 ## Usage
@@ -54,7 +54,7 @@ except they are called before and after each individual test.
 Below are some examples of how to use `describe` and `it` in tests.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.14.0/mod.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.15.0/mod.ts)
 for more information.
 
 ### Nested test grouping
@@ -67,13 +67,13 @@ import {
   beforeEach,
   describe,
   it,
-} from "https://deno.land/x/test_suite@0.14.0/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.130.0/testing/asserts.ts";
+} from "https://deno.land/x/test_suite@0.15.0/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.133.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.14.0/examples/user.ts";
+} from "https://deno.land/x/test_suite@0.15.0/examples/user.ts";
 
 describe("user describe", () => {
   let user: User;
@@ -131,13 +131,13 @@ test result: ok. 1 passed (5 steps); 0 failed; 0 ignored; 0 measured; 0 filtered
 The example below can be found [here](examples/user_flat_test.ts).
 
 ```ts
-import { describe, it } from "https://deno.land/x/test_suite@0.14.0/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.130.0/testing/asserts.ts";
+import { describe, it } from "https://deno.land/x/test_suite@0.15.0/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.133.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.14.0/examples/user.ts";
+} from "https://deno.land/x/test_suite@0.15.0/examples/user.ts";
 
 interface UserContext {
   user: User;

--- a/describe_test.ts
+++ b/describe_test.ts
@@ -116,7 +116,8 @@ Deno.test("global", async (t) => {
       assertSpyCalls(fns[0], 0);
       assertSpyCalls(fns[1], 0);
 
-      const call = assertSpyCall(test, 0);
+      assertSpyCall(test, 0);
+      const call = test.calls[0];
       const options = call.args[0] as Deno.TestDefinition;
       assertEquals(Object.keys(options).sort(), ["fn", "name"]);
       assertEquals(options.name, "global");
@@ -164,7 +165,8 @@ Deno.test("global", async (t) => {
         cb(fn);
 
         assertSpyCalls(fn, 0);
-        const call = assertSpyCall(test, 0);
+        assertSpyCall(test, 0);
+        const call = test.calls[0];
         const options = call.args[0] as Deno.TestDefinition;
         assertEquals(
           Object.keys(options).sort(),
@@ -632,7 +634,8 @@ Deno.test("global", async (t) => {
       try {
         cb(fns);
 
-        const call = assertSpyCall(test, 0);
+        assertSpyCall(test, 0);
+        const call = test.calls[0];
         const options = call.args[0] as Deno.TestDefinition;
         assertEquals(
           Object.keys(options).sort(),
@@ -1237,7 +1240,8 @@ Deno.test("global", async (t) => {
         try {
           cb(fns);
 
-          const call = assertSpyCall(test, 0);
+          assertSpyCall(test, 0);
+          const call = test.calls[0];
           const options = call.args[0] as Deno.TestDefinition;
           assertEquals(
             Object.keys(options).sort(),
@@ -1342,7 +1346,8 @@ Deno.test("global", async (t) => {
           assertSpyCalls(fns[0], 0);
           assertSpyCalls(fns[1], 0);
 
-          const call = assertSpyCall(test, 0);
+          assertSpyCall(test, 0);
+          const call = test.calls[0];
           const options = call.args[0] as Deno.TestDefinition;
           assertEquals(Object.keys(options).sort(), ["fn", "name"]);
           assertEquals(options.name, "example");
@@ -1448,7 +1453,8 @@ Deno.test("global", async (t) => {
             assertSpyCalls(fns[0], 0);
             assertSpyCalls(fns[1], 0);
 
-            const call = assertSpyCall(test, 0);
+            assertSpyCall(test, 0);
+            const call = test.calls[0];
             const options = call.args[0] as Deno.TestDefinition;
             assertEquals(Object.keys(options).sort(), ["fn", "name"]);
             assertEquals(options.name, "example");
@@ -1554,7 +1560,8 @@ Deno.test("global", async (t) => {
             assertSpyCalls(fns[0], 0);
             assertSpyCalls(fns[1], 0);
 
-            const call = assertSpyCall(test, 0);
+            assertSpyCall(test, 0);
+            const call = test.calls[0];
             const options = call.args[0] as Deno.TestDefinition;
             assertEquals(Object.keys(options).sort(), ["fn", "name"]);
             assertEquals(options.name, "example");

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -6,16 +6,16 @@ export {
   assertRejects,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.130.0/testing/asserts.ts";
+} from "https://deno.land/std@0.133.0/testing/asserts.ts";
 
 export {
   assertSpyCall,
   assertSpyCalls,
   spy,
   stub,
-} from "https://deno.land/x/mock@0.15.0/mod.ts";
+} from "https://deno.land/std@0.133.0/testing/mock.ts";
 export type {
   Spy,
   SpyCall,
   Stub,
-} from "https://deno.land/x/mock@0.15.0/mod.ts";
+} from "https://deno.land/std@0.133.0/testing/mock.ts";

--- a/test_suite.ts
+++ b/test_suite.ts
@@ -200,6 +200,13 @@ export class TestSuiteInternal<T> implements TestSuite<T> {
       }
       suite.hasOnlyStep = true;
     }
+
+    const parentSuite = suite.describe.suite;
+    const parentTestSuite = parentSuite &&
+      TestSuiteInternal.suites.get(parentSuite.symbol);
+    if (parentTestSuite) {
+      TestSuiteInternal.addingOnlyStep(parentTestSuite);
+    }
   }
 
   /** This is used internally to add steps to a test suite. */


### PR DESCRIPTION
The only option was meant to apply for the entire top level test case rather than only the current suite.