### PR TITLE
Fix only on multiple tests in different suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Test Suite
 
-[![version](https://img.shields.io/badge/release-0.15.0-success)](https://deno.land/x/test_suite@0.15.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.15.0/mod.ts)
+[![version](https://img.shields.io/badge/release-0.16.0-success)](https://deno.land/x/test_suite@0.16.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/test_suite@0.16.0/mod.ts)
 [![CI](https://github.com/udibo/test_suite/workflows/CI/badge.svg)](https://github.com/udibo/test_suite/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/test_suite/branch/main/graph/badge.svg?token=EFKGY72AAV)](https://codecov.io/gh/udibo/test_suite)
 [![license](https://img.shields.io/github/license/udibo/test_suite)](https://github.com/udibo/test_suite/blob/master/LICENSE)
@@ -26,12 +26,12 @@ also be imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { describe, it } from "https://deno.land/x/test_suite@0.15.0/mod.ts";
+import { describe, it } from "https://deno.land/x/test_suite@0.16.0/mod.ts";
 // Import from GitHub
 import {
   describe,
   it,
-} from "https://raw.githubusercontent.com/udibo/test_suite/0.15.0/mod.ts";
+} from "https://raw.githubusercontent.com/udibo/test_suite/0.16.0/mod.ts";
 ```
 
 ## Usage
@@ -54,7 +54,7 @@ except they are called before and after each individual test.
 Below are some examples of how to use `describe` and `it` in tests.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.15.0/mod.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/test_suite@0.16.0/mod.ts)
 for more information.
 
 ### Nested test grouping
@@ -67,13 +67,13 @@ import {
   beforeEach,
   describe,
   it,
-} from "https://deno.land/x/test_suite@0.15.0/mod.ts";
+} from "https://deno.land/x/test_suite@0.16.0/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.133.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.15.0/examples/user.ts";
+} from "https://deno.land/x/test_suite@0.16.0/examples/user.ts";
 
 describe("user describe", () => {
   let user: User;
@@ -131,13 +131,13 @@ test result: ok. 1 passed (5 steps); 0 failed; 0 ignored; 0 measured; 0 filtered
 The example below can be found [here](examples/user_flat_test.ts).
 
 ```ts
-import { describe, it } from "https://deno.land/x/test_suite@0.15.0/mod.ts";
+import { describe, it } from "https://deno.land/x/test_suite@0.16.0/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.133.0/testing/asserts.ts";
 import {
   getUser,
   resetUsers,
   User,
-} from "https://deno.land/x/test_suite@0.15.0/examples/user.ts";
+} from "https://deno.land/x/test_suite@0.16.0/examples/user.ts";
 
 interface UserContext {
   user: User;


### PR DESCRIPTION
If the focused test cases were nested in different describe blocks and one has only, the focused test cases in following describe blocks would not get registered. That's because any test suite that was not focused would end up getting omitted from the array of steps, even if it ends up having a child with only.

To fix this, I switched from omitting test suites at registration to only doing so while the tests are running.